### PR TITLE
Fix for new docker compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Enable to start service via.
     * e.g. DOCKER\_MT\_SERVICES=postfix
+* Support docker-compose 2.x
 
 ### Fixed
 

--- a/mt/cgi.yml
+++ b/mt/cgi.yml
@@ -3,3 +3,6 @@ services:
   mt:
     restart: always
     command: "/usr/sbin/httpd -D FOREGROUND"
+
+  mt-watcher:
+    command: "/bin/true"

--- a/mt/common.yml
+++ b/mt/common.yml
@@ -38,7 +38,16 @@ services:
     command: apache2-foreground
 
   mt-watcher:
-    image: busybox
+    build:
+      context: mt-watcher
+    working_dir: /var/www/cgi-bin/mt
+    environment:
+      PERL_FNS_NO_OPT: ${PERL_FNS_NO_OPT:-0}
+      DISABLE_MT_WATCHER: ${DISABLE_MT_WATCHER:-0}
+    volumes:
+      - "${MT_HOME_PATH:-../../movabletype}:/var/www/cgi-bin/mt"
+      - "./mt-watcher.pl:/usr/local/lib/mt/bin/mt-watcher.pl"
+      - /var/run/docker.sock:/var/run/docker.sock
 
 volumes:
   site:

--- a/mt/common.yml
+++ b/mt/common.yml
@@ -17,6 +17,8 @@ services:
       - "support:/var/www/cgi-bin/mt/mt-static/support"
       # override entrypoint
       - "./docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh"
+    labels:
+      mt-dev.service: "mt"
 
   httpd:
     image: ${DOCKER_HTTPD_IMAGE:-movabletype/test:php-7.3}

--- a/mt/mt-watcher.pl
+++ b/mt/mt-watcher.pl
@@ -31,7 +31,8 @@ while (1) {
             return unless @paths;
 
             print( join( "\n", @paths ) . "\n" );
-            system('docker kill -s HUP mt_mt_1');
+            my $mt_container_id = `docker ps -q --filter label=mt-dev.service=mt`;
+            system("docker kill -s HUP $mt_container_id");
 
             # throttling
             sleep(1);

--- a/mt/psgi.yml
+++ b/mt/psgi.yml
@@ -7,16 +7,6 @@ services:
       MT_PID_FILE_PATH: ${MT_PID_FILE_PATH:-/tmp/mt.psgi.pid}
     volumes:
       - "./plackup-mt:/usr/local/lib/mt/bin/plackup-mt"
+
   mt-watcher:
-    build:
-      context: mt-watcher
-    image: movabletype/mt-watcher
-    working_dir: /var/www/cgi-bin/mt
     command: /usr/local/lib/mt/bin/mt-watcher.pl
-    environment:
-      PERL_FNS_NO_OPT: ${PERL_FNS_NO_OPT:-0}
-      DISABLE_MT_WATCHER: ${DISABLE_MT_WATCHER:-0}
-    volumes:
-      - "${MT_HOME_PATH:-../../movabletype}:/var/www/cgi-bin/mt"
-      - "./mt-watcher.pl:/usr/local/lib/mt/bin/mt-watcher.pl"
-      - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
#9 の修正です。
cocker-compose 2.x 向けの変更ですが、入れてしまっても 1.x では問題はないものなので、レビューがOKならmasterに入れて行きたいと思います。

### pull の問題

`--ignore-pull-failures` でも回避できるのですが、エラーを無視するのは好ましくないため別のアプローチにしました。
これまでは、
* common.yml で busybox を指定
* psgi.yml で利用するイメージをビルド

としてきましたが、これを以下のように変更します。

* common.yml で利用するイメージをビルド
* psgi.yml で監視するコマンドを指定して監視する
* cgi.yml では /bin/true のコマンドを指定して即終了する

いずれにしてもややこしいところではあるのですが、 `bin/setup-environment` が生成する yml で mt-watcher を指定するという構成から考えると、これでもよいかなと思っています。

性能的には、 CGI の場合にもこれまでと同じくすぐに終了するし、 mt-watcher のコンテナも小さいものなので、これまでと大きく変わることはないと思います。


### kill の問題

docker-compose の仕様に依存せず、 label で指定するようにしました。
このやり方だと「複数の開発環境を立ち上げている時に、（同じlabelで複数の mt のコンテナが起動されることになるので）全部のコンテナに送信してしまう」ということにはなりますが、
* 複数の開発環境を立ち上げるということは想定しづらい
* 万が一あったとしても、全部のコンテナに送信してもそこまで問題ないだろう

ということで、比較的簡易的にこのようにしています。