### PR TITLE
Support docker compose cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MAKEFILE_DIR=$(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 export BASE_SITE_PATH:=${MAKEFILE_DIR}/site
 export DOCKER:=docker
-export DOCKER_COMPOSE:=docker-compose
+export DOCKER_COMPOSE:=${shell ${DOCKER} compose >/dev/null 2>&1 && echo 'docker compose' || echo 'docker-compose'}
 export DOCKER_COMPOSE_YML_MIDDLEWARES:=-f ./mt/mysql.yml -f ./mt/memcached.yml
 export UP_ARGS:=-d
 export MT_HOME_PATH:=${MAKEFILE_DIR}/../movabletype

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 MAKEFILE_DIR=$(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
-export BASE_SITE_PATH=${MAKEFILE_DIR}/site
-export DOCKER=docker
-export DOCKER_COMPOSE=docker-compose
-export DOCKER_COMPOSE_YML_MIDDLEWARES=-f ./mt/mysql.yml -f ./mt/memcached.yml
-export UP_ARGS=-d
-export MT_HOME_PATH=${MAKEFILE_DIR}/../movabletype
-export UPDATE_BRANCH=yes
+export BASE_SITE_PATH:=${MAKEFILE_DIR}/site
+export DOCKER:=docker
+export DOCKER_COMPOSE:=docker-compose
+export DOCKER_COMPOSE_YML_MIDDLEWARES:=-f ./mt/mysql.yml -f ./mt/memcached.yml
+export UP_ARGS:=-d
+export MT_HOME_PATH:=${MAKEFILE_DIR}/../movabletype
+export UPDATE_BRANCH:=yes
 
 MT_CONFIG_CGI=${shell [ -e mt-config.cgi ] && echo mt-config.cgi || echo mt-config.cgi-original}
 BASE_ARCHIVE_PATH=${MAKEFILE_DIR}/archive


### PR DESCRIPTION
#11

* 3e83dd2 : ついでですが、今まで環境変数から値を設定できなかったので、できるようにしました
* ebfd00f : `docker compose` が利用できればそれを使い、利用できなければ `docker-compose` を使うことにしました

`docker compose` は現時点で完成度が高いようで、ほぼほぼ一緒なので、優先度はどちらでもよかったのですが、「 `docker compose` も使えず、かつ `docker-compose` もインストールされていない」という環境では、 `docker-compose` にフォールバックしておいた方がエラーメッセージが分かりやすいと思うのでこのようにしました。

また `docker compose` では python 依存もなくなるので、おそらくこれが主流になっていくだろうとも思うので、その意味でも `docker compose` を優先でよいかなと思っています。