### PR TITLE
Add cloud-init.yaml for Ubuntu 20.04.

### DIFF
--- a/config/cloud-init-ubuntu-20.04.yaml
+++ b/config/cloud-init-ubuntu-20.04.yaml
@@ -1,0 +1,19 @@
+#cloud-config
+
+runcmd:
+  - /bin/bash
+  - -c
+  - |
+    #!/bin/bash
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y make git zip \
+      docker.io \
+      mysql-client
+    # required by HTTP::Tiny
+    apt-get install -y libio-socket-ssl-perl
+    curl -L https://github.com/docker/compose/releases/download/1.26.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose
+    # for NFS
+    apt-get install -y nfs-common
+    adduser ubuntu docker


### PR DESCRIPTION
```
$ multipass launch --cpus 4 --disk 16G --mem 3G -n mt-dev --cloud-init config/cloud-init-ubuntu-20.04.yaml
$ multipass mount . mt-dev:/home/ubuntu/mt-dev
$ ssh mt-dev-at-multipass # Use ssh instead of `multipass shell` to work with ssh agent forwarding
ubuntu@mt-dev:~$ make -C mt-dev up-psgi
```

### See also

* [multipassのVMにsshで接続](https://hnakamur.github.io/blog/2019/10/21/access-multipass-vm-via-ssh/)