### PR TITLE
Include extlib

### DIFF
--- a/mt/plackup-mt
+++ b/mt/plackup-mt
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 exec starman \
+    -Iextlib \
     -MCGI \
     -MFile::Spec \
     -MCGI::Cookie \


### PR DESCRIPTION
to avoid loading an incompatible module with the bundled one.