### PR TITLE
Amd64 on arm64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * Ensure that binaries with the appropriate architecture are installed even if BuildKit is disabled.
     * Reduced image size by using "perl:*-slim" images.
 
+### Fixed
+
+* Add workaround to run amd64 image on arm64.
+
 ## [2.2.0] - 2023-02-15
 
 ### Added

--- a/mt/docker-entrypoint.sh
+++ b/mt/docker-entrypoint.sh
@@ -23,7 +23,7 @@ $SUDO chmod 777 /var/www/cgi-bin/mt/themes
 if [ "$1" = "apache2-foreground" ]; then
     # invoke php-fpm
     if [ -e /usr/sbin/php-fpm ]; then
-        mkdir /run/php-fpm
+        mkdir -p /run/php-fpm
         /usr/sbin/php-fpm
     fi
 

--- a/mt/httpd/build-script/apache2.sh
+++ b/mt/httpd/build-script/apache2.sh
@@ -13,6 +13,9 @@ Timeout 3600
 
 # mt-static
 Alias /mt-static/ /var/www/cgi-bin/mt/mt-static/
+
+# Workaround to run amd64 image on arm64
+Mutex posixsem
 CONF
 
 mod_rewrite_so=`find $module_dirs -name 'mod_rewrite.so' 2>/dev/null | head -1`


### PR DESCRIPTION
M1 上の Dockerdesktop で起動した際に、 httpd のイメージが amd64 だと以下のようなメッセージで httpd 落ちることがあるので、それを回避する。

```
(95)Operation not supported: AH00023: Couldn't create the ssl-cache mutex
```

