### PR TITLE
/bin/bash to /usr/bin/env bash

### DIFF
--- a/bin/extract-archive
+++ b/bin/extract-archive
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 set -o pipefail
 
 if type md5sum >/dev/null 2>&1; then

--- a/bin/git-clone
+++ b/bin/git-clone
@@ -1,4 +1,5 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash
+set -xe
 set -o pipefail
 
 repo=$1

--- a/bin/teardown-environment
+++ b/bin/teardown-environment
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 rm -fr /tmp/mt-dev-archive-temp-* || \
     echo "Failed to remove temporary directory:" /tmp/mt-dev-archive-temp-*

--- a/mt/plackup-mt
+++ b/mt/plackup-mt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 exec starman \
     -Iextlib \

--- a/ssl/generate-certs.sh
+++ b/ssl/generate-certs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 mkdir -p certs
 touch index.txt


### PR DESCRIPTION
In a native Linux environment (especially in a specialized distribution like NixOS), /bin/bash may not be available, so I changed it to /usr/bin/env bash."