### PR TITLE
specify docker api version number

### DIFF
--- a/mt/mt-watcher.pl
+++ b/mt/mt-watcher.pl
@@ -31,8 +31,8 @@ while (1) {
             return unless @paths;
 
             print( join( "\n", @paths ) . "\n" );
-            my $mt_container_id = `docker ps -q --filter label=mt-dev.service=mt`;
-            system("docker kill -s HUP $mt_container_id");
+            my $mt_container_id = `DOCKER_API_VERSION=1.44 docker ps -q --filter label=mt-dev.service=mt`;
+            system("DOCKER_API_VERSION=1.44 docker kill -s HUP $mt_container_id");
 
             # throttling
             sleep(1);


### PR DESCRIPTION
ファイル更新時に下記のエラーが発生していて、このPRで回避できました。正しい修正でないかもしれません。

```
$ docker logs -f mt-mt-watcher-1
/var/www/cgi-bin/mt/lib/MT.pm
Error response from daemon: client version 1.41 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version
"docker kill" requires at least 1 argument.
See 'docker kill --help'.

Usage:  docker kill [OPTIONS] CONTAINER [CONTAINER...]

Kill one or more running containers
```

docker version は下記です。

```
$ docker exec -it mt-mt-watcher-1 docker version
Client:
 Version:           20.10.9
 API version:       1.41
 Go version:        go1.16.8
 Git commit:        c2ea9bc
 Built:             Mon Oct  4 16:03:36 2021
 OS/Arch:           linux/arm64
 Context:           default
 Experimental:      true
```